### PR TITLE
HN script updates (using official API, CLI args support)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "esnext": true,
+  "laxcomma": true,
+  "node": true
+}

--- a/README.md
+++ b/README.md
@@ -17,17 +17,33 @@ Before installation you will need node/npm installed.
 
 
     sudo npm install -g hacker-news-cli
-    
+
 ##Usage
 
 The global installation will symlink an executable script and place it in your PATH. To use with hacker news simply type:
 
     hn
-    
+
+or use `--help` to show available options:
+
+    hn --help
+
+    A command line tool to print out the latest posts on Hacker News to your terminal.
+
+    Usage
+    $ hn <option> [parameters]
+
+    Examples of usage
+    $ hn --limit 10
+
+    Options
+    --limit n  # Displays first n hottest posts.  Default:  29
+    --version  # Displays package version.
+
 or for designer news:
 
     dn
-    
+
 You will then be prompted to open a post. Type the number of the post to open a post or type 0 to quit and return to your terminal session.
 
 ##Version history

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var FeedParser = require('feedparser')
   , colors = require('colors')
   , prompt = require('prompt')
   , exec = require('child_process').exec
+  , meow = require('meow')
   , platform = require('os').platform();
 
 const shellOpenCommand = {
@@ -15,11 +16,29 @@ const shellOpenCommand = {
   'darwin': 'open '
 }[platform];
 
+const defaults = {
+  'limit': 29
+};
+
 const hnUrls = {
   'item': 'https://news.ycombinator.com/item?id='
 };
 
-hackerNews.getHottestItems(28, function(err, items) {
+var cli = meow({
+  help: [
+    'Usage',
+    '  $ hn <option> [parameters]',
+    '',
+    'Examples of usage',
+    '  $ hn --limit 10',
+    '',
+    'Options',
+    '  --limit n  # Displays first n hottest posts.  Default: 29',
+    '  --version  # Displays package version.',
+  ]
+});
+
+hackerNews.getHottestItems(getLimit(), function(err, items) {
   if (err) {
     throw err;
   }
@@ -27,6 +46,13 @@ hackerNews.getHottestItems(28, function(err, items) {
   posts = items.slice();
   async.each(posts, printPostTitle, promptForPost);
 });
+
+function getLimit() {
+  return isNaN(cli.flags.limit)
+    || !cli.flags.limit
+    ? defaults.limit
+    : cli.flags.limit;
+}
 
 function printPostTitle(post, next) {
   console.log((posts.indexOf(post) + 1).toString().red + ". " + post.title);

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "url": "https://github.com/mtharrison/hackernews/issues"
   },
   "dependencies": {
-    "request": "~2.27.0",
-    "feedparser": "~0.16.2",
+    "async": "^1.3.0",
     "colors": "~0.6.2",
-    "prompt": "~0.2.11"
+    "feedparser": "~0.16.2",
+    "node-hacker-news": "^0.1.1",
+    "prompt": "~0.2.11",
+    "request": "~2.27.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "preferGlobal": true,
   "bin": {
     "hn": "./index.js",
     "dn": "./designer.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "async": "^1.3.0",
     "colors": "~0.6.2",
     "feedparser": "~0.16.2",
+    "meow": "^3.3.0",
     "node-hacker-news": "^0.1.1",
     "prompt": "~0.2.11",
     "request": "~2.27.0"


### PR DESCRIPTION
- Now using official Hacker News API via [node-hacker-news](https://github.com/edwellbrook/node-hacker-news) (should cover https://github.com/mtharrison/hackernews/issues/10)
- Added CLI input handler ([meow](https://github.com/sindresorhus/meow) that is using [minimist](https://github.com/substack/minimist)). Currently only few options are actually used:
  * `--limit n` option to show only first `n` hottest posts
  * Some out of the box (`--help`, `--version`)
- Added some JShint settings
- Also [preferGlobal](https://docs.npmjs.com/files/package.json#preferglobal) added to package.json
